### PR TITLE
Branch to make it easier to add a parser for manufacturer-specific data in advertisements

### DIFF
--- a/app/src/main/java/org/ligi/blexplorer/scan/DeviceViewHolder.java
+++ b/app/src/main/java/org/ligi/blexplorer/scan/DeviceViewHolder.java
@@ -15,6 +15,7 @@ import java.math.BigInteger;
 import org.ligi.blexplorer.App;
 import org.ligi.blexplorer.R;
 import org.ligi.blexplorer.services.DeviceServiceExploreActivity;
+import org.ligi.blexplorer.util.ManufacturerRecordParserFactory;
 import org.ligi.blexplorer.util.from_lollipop.ScanRecord;
 import static org.ligi.blexplorer.util.DevicePropertiesDescriber.describeBondState;
 import static org.ligi.blexplorer.util.DevicePropertiesDescriber.describeType;
@@ -63,7 +64,12 @@ public class DeviceViewHolder extends RecyclerView.ViewHolder {
 
         for (int i = 0; i < manufacturerSpecificData.size(); i++) {
             final int key = manufacturerSpecificData.keyAt(i);
-            scanRecordStr += key + "=" + new BigInteger(1, manufacturerSpecificData.get(key)).toString(16) + "\n";
+            ManufacturerRecordParserFactory.ManufacturerParserBase p = ManufacturerRecordParserFactory.parse(key, manufacturerSpecificData.get(key));
+            if (p == null) {
+                scanRecordStr += key + "=" + new BigInteger(1, manufacturerSpecificData.get(key)).toString(16) + "\n";
+            } else {
+                scanRecordStr += p.getKeyDescriptor() + " = {\n" + p.toString() + "}\n";
+            }
         }
 
         for (final ParcelUuid parcelUuid : scanRecord.getServiceData().keySet()) {

--- a/app/src/main/java/org/ligi/blexplorer/util/DevicePropertiesDescriber.java
+++ b/app/src/main/java/org/ligi/blexplorer/util/DevicePropertiesDescriber.java
@@ -18,13 +18,13 @@ public class DevicePropertiesDescriber {
     public static String describeBondState(BluetoothDevice device) {
         switch (device.getBondState()) {
             case BluetoothDevice.BOND_NONE:
-                return "none";
+                return "not bonded";
             case BluetoothDevice.BOND_BONDING:
                 return "bonding";
             case BluetoothDevice.BOND_BONDED:
                 return "bonded";
             default:
-                return "unknown";
+                return "unknown bondstate";
         }
     }
 
@@ -38,7 +38,7 @@ public class DevicePropertiesDescriber {
                 return "LE";
             default:
             case BluetoothDevice.DEVICE_TYPE_UNKNOWN:
-                return "unknown";
+                return "unknown device type";
         }
     }
 
@@ -53,7 +53,7 @@ public class DevicePropertiesDescriber {
             case BluetoothGattService.SERVICE_TYPE_SECONDARY:
                 return "secondary";
             default:
-                return "unknown";
+                return "unknown service type";
         }
     }
 
@@ -84,7 +84,7 @@ public class DevicePropertiesDescriber {
                 return "write signed mitm";
 
             default:
-                return "unknown" + from.getPermissions();
+                return "unknown permission" + from.getPermissions();
         }
     }
 

--- a/app/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
+++ b/app/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
@@ -1,0 +1,167 @@
+package org.ligi.blexplorer.util;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+import android.util.SparseArray;
+
+import java.math.BigInteger;
+
+public final class ManufacturerRecordParserFactory {
+
+    private static final String TAG = "ManufacturerParser";
+
+    private final SparseArray<Class<? extends ManufacturerParserBase>> mParserTemplates =
+            new SparseArray<Class<? extends ManufacturerParserBase>>();
+
+    static protected ManufacturerRecordParserFactory sParserFactory;
+
+    static {
+        // Load the factory with the samplers we support
+        sParserFactory = new ManufacturerRecordParserFactory(
+                IBeaconParser.class
+        );
+    }
+
+    static public ManufacturerParserBase parse(int cic, byte[] record) {
+        ManufacturerParserBase p = sParserFactory.getParser(cic);
+        if (p != null)
+            if (!p.parse(record))
+                return null;
+        return p;
+    }
+
+    // Convenience constructor, variable arguments
+    public ManufacturerRecordParserFactory(Class<? extends ManufacturerParserBase>... parserClasses) {
+        for (Class<? extends ManufacturerParserBase> parser : parserClasses) {
+            putParser(parser);
+        }
+    }
+
+    public final void putParser(Class<? extends ManufacturerParserBase> Parser) {
+        // Instantiate a temporary of the class so that we can query some
+        // of the virtuals
+        ManufacturerParserBase parserObject;
+        try {
+            parserObject = Parser.newInstance();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+            return;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            return;
+        }
+
+        int companyIdentifierCode = parserObject.getCompanyIdentifierCode();
+        if (mParserTemplates.get(companyIdentifierCode) != null) {
+            Log.e(TAG, "Can't add the same (" + companyIdentifierCode + ") parser twice");
+            return;
+        }
+        mParserTemplates.put(companyIdentifierCode, Parser);
+    }
+
+    @Nullable
+    public ManufacturerParserBase getParser(int companyIdentifierCode) {
+        Class<? extends ManufacturerParserBase> parserClass = mParserTemplates.get(companyIdentifierCode);
+        if (parserClass == null) {
+            return null;
+        }
+        try {
+            ManufacturerParserBase parser = parserClass.newInstance();
+            if (parser == null)
+                return null;
+            return parser;
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+            return null;
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+
+    static public abstract class ManufacturerParserBase {
+        protected int mType;
+        protected int mLen;
+        protected byte[] mBytes = null;
+
+        public ManufacturerParserBase() {
+        }
+
+        /**
+         * https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers
+         *
+         * @return code from
+         */
+        public abstract int getCompanyIdentifierCode();
+
+        public String getKeyDescriptor() {
+            return "" + getCompanyIdentifierCode();
+        }
+
+        /**
+         * Expect to be given that part of the scanRecord that was the 0xff manufacturer specifc
+         * record, but with the manufacturer identifier already removed, and the array clipped
+         * to the size of the field.
+         *
+         * @return success
+         */
+        public abstract boolean parse(byte[] manufacturerData);
+    }
+
+    static protected class IBeaconParser extends ManufacturerParserBase {
+        private BigInteger mUUID;
+        private int mMajor;
+        private int mMinor;
+        private int mTXPower;
+
+        public IBeaconParser() {
+            super();
+        }
+
+        @Override
+        public int getCompanyIdentifierCode() {
+            return 0x4c;
+        }
+
+        public String getKeyDescriptor() {
+            return "iBeacon";
+        }
+
+        @Override
+        public boolean parse(byte[] manufacturerData) {
+            // <apple record type> <apple record len> <apple record>
+            int index = 0;
+            while (index < manufacturerData.length) {
+                mType = manufacturerData[index] & 0xff;
+                mLen = manufacturerData[index + 1] & 0xff;
+
+                mBytes = new byte[mLen];
+                System.arraycopy(manufacturerData, index + 2, mBytes, 0, mBytes.length);
+                index += mLen + 2;
+
+                // Only support iBeacon parsing
+                if (mType != 0x02) {
+                    continue;
+                }
+
+                byte[] uuidbytes = new byte[16];
+                System.arraycopy(mBytes, 0, uuidbytes, 0, uuidbytes.length);
+                mUUID = new BigInteger(1, uuidbytes);
+                mMajor = (mBytes[17] << 8 | mBytes[16]) & 0xffff;
+                mMinor = (mBytes[19] << 8 | mBytes[18]) & 0xffff;
+                mTXPower = mBytes[20];
+            }
+
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "uuid = " + mUUID.toString(16)
+                    + "\nmajor = " + mMajor + "\nminor = " + mMinor
+                    + "\ntxPower = " + mTXPower + "dBm";
+        }
+    }
+}
+


### PR DESCRIPTION
For a project I'm working on with a BLE beacon, I wanted a way of parsing the data I was putting in the advertisement.  BLExplorer was a perfect base for that, so I added a bit of a structure to make that easier.  My own advertisements are likely no use to anyone else, but I thought the structure might be.  I've put an iBeacon parser in just to show how it might work, and thought I'd to a pull request in case it would be useful back in the mainline version.
