### PR TITLE
Make it possible for ManufacturerRecordParser to supply a device name

### DIFF
--- a/android/src/main/java/org/ligi/blexplorer/scan/DeviceViewHolder.kt
+++ b/android/src/main/java/org/ligi/blexplorer/scan/DeviceViewHolder.kt
@@ -39,11 +39,14 @@ class DeviceViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
 
         for (i in 0..manufacturerSpecificData.size() - 1) {
             val key = manufacturerSpecificData.keyAt(i)
-            val p = ManufacturerRecordParserFactory.parse(key, manufacturerSpecificData.get(key))
+            val p = ManufacturerRecordParserFactory.parse(key, manufacturerSpecificData.get(key), device)
             if (p == null) {
                 scanRecordStr += "$key=" + BigInteger(1, manufacturerSpecificData.get(key)).toString(16) + "\n"
             } else {
                 scanRecordStr += p.keyDescriptor + " = {\n" + p.toString() + "}\n"
+                if (!TextUtils.isEmpty(p.getName(device))) {
+                    itemView.name.text = p.getName(device);
+                }
             }
         }
 

--- a/android/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
+++ b/android/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
@@ -1,6 +1,8 @@
 package org.ligi.blexplorer.util;
 
+import android.bluetooth.BluetoothDevice;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -22,10 +24,10 @@ public final class ManufacturerRecordParserFactory {
         );
     }
 
-    static public ManufacturerParserBase parse(int cic, byte[] record) {
+    static public ManufacturerParserBase parse(int cic, byte[] record, BluetoothDevice device) {
         ManufacturerParserBase p = sParserFactory.getParser(cic);
         if (p != null)
-            if (!p.parse(record))
+            if (!p.parse(record, device))
                 return null;
         return p;
     }
@@ -99,6 +101,14 @@ public final class ManufacturerRecordParserFactory {
             return "" + getCompanyIdentifierCode();
         }
 
+        public String getName(BluetoothDevice device) {
+            if (TextUtils.isEmpty(device.getName())) {
+                return "no name";
+            } else {
+                return device.getName();
+            }
+        }
+
         /**
          * Expect to be given that part of the scanRecord that was the 0xff manufacturer specifc
          * record, but with the manufacturer identifier already removed, and the array clipped
@@ -106,7 +116,7 @@ public final class ManufacturerRecordParserFactory {
          *
          * @return success
          */
-        public abstract boolean parse(byte[] manufacturerData);
+        public abstract boolean parse(byte[] manufacturerData, BluetoothDevice device);
     }
 
     static protected class IBeaconParser extends ManufacturerParserBase {
@@ -129,7 +139,7 @@ public final class ManufacturerRecordParserFactory {
         }
 
         @Override
-        public boolean parse(byte[] manufacturerData) {
+        public boolean parse(byte[] manufacturerData, BluetoothDevice device) {
             // <apple record type> <apple record len> <apple record>
             int index = 0;
             while (index < manufacturerData.length) {


### PR DESCRIPTION
It only does it if no device name was available from the scan record
itself; but it's possible that the manufacturer-specific record in the
BLE advert gives enough information to supply a name.  It's nice to
offer the custom parser the ability to display that name.