### PR TITLE
Changed the 0x1815 GATT service number to 0x1816

### DIFF
--- a/android/src/main/assets/services.json
+++ b/android/src/main/assets/services.json
@@ -76,6 +76,10 @@
     "type": "org.bluetooth.service.running_speed_and_cadence"
   },
   "1815": {
+    "name": "Automation IO",
+    "type": "org.bluetooth.service.automation_io"
+  },
+  "1816": {
     "name": "Cycling Speed and Cadence",
     "type": "org.bluetooth.service.cycling_speed_and_cadence"
   }


### PR DESCRIPTION
According to https://www.bluetooth.com/specifications/gatt/services/, the 0x1815 number belongs to Automation IO, while Cycling Speed and Cadence is identified by 0x1816.