### PR TITLE
fix crash in case of incomplete manufacturerData

### DIFF
--- a/android/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
+++ b/android/src/main/java/org/ligi/blexplorer/util/ManufacturerRecordParserFactory.java
@@ -142,9 +142,14 @@ public final class ManufacturerRecordParserFactory {
         public boolean parse(byte[] manufacturerData, BluetoothDevice device) {
             // <apple record type> <apple record len> <apple record>
             int index = 0;
-            while (index < manufacturerData.length) {
+            while ((index + 2) <= manufacturerData.length) {
                 mType = manufacturerData[index] & 0xff;
                 mLen = manufacturerData[index + 1] & 0xff;
+
+                if ((index + 2 + mLen) > manufacturerData.length) {
+                    // Not enough data
+                    break;
+                }
 
                 mBytes = new byte[mLen];
                 System.arraycopy(manufacturerData, index + 2, mBytes, 0, mBytes.length);


### PR DESCRIPTION
arraycopy will throw an ArrayIndexOutOfBoundsException if the source
does not have enough data

Crash confirmed and fix tested successfully with current master.

Crash first encountered with BLExplorer 1.2 from FDroid:
```
2020-03-06 15:14:01.611 26618-26618/? I/art: Late-enabling -Xcheck:jni
2020-03-06 15:14:01.661 26618-26618/org.ligi.blexplorer W/System: ClassLoader referenced unknown path: /data/app/org.ligi.blexplorer-1/lib/arm
2020-03-06 15:14:01.673 26618-26618/org.ligi.blexplorer D/TraceDroid: current handler class=com.android.internal.os.RuntimeInit$UncaughtHandler
2020-03-06 15:14:01.690 26618-26618/org.ligi.blexplorer W/art: Before Android 4.1, method android.graphics.PorterDuffColorFilter android.support.graphics.drawable.VectorDrawableCompat.updateTintFilter(android.graphics.PorterDuffColorFilter, android.content.res.ColorStateList, android.graphics.PorterDuff$Mode) would have incorrectly overridden the package-private method in android.graphics.drawable.Drawable
2020-03-06 15:14:01.750 26618-26631/org.ligi.blexplorer D/BluetoothLeScanner: onClientRegistered() - status=0 clientIf=6 mClientIf=0
2020-03-06 15:14:01.801 26618-26634/org.ligi.blexplorer I/Adreno: QUALCOMM build                   : a9083cf, Iaf618d42e3
    Build Date                       : 03/14/17
    OpenGL ES Shader Compiler Version: XE031.09.00.04
    Local Branch                     : 
    Remote Branch                    : 
    Remote Branch                    : 
    Reconstruct Branch               : 
2020-03-06 15:14:01.808 26618-26634/org.ligi.blexplorer I/OpenGLRenderer: Initialized EGL, version 1.4
2020-03-06 15:14:01.808 26618-26634/org.ligi.blexplorer D/OpenGLRenderer: Swap behavior 1
2020-03-06 15:14:06.836 26618-26623/org.ligi.blexplorer I/art: Do partial code cache collection, code=21KB, data=31KB
2020-03-06 15:14:06.837 26618-26623/org.ligi.blexplorer I/art: After code cache collection, code=21KB, data=31KB
2020-03-06 15:14:06.837 26618-26623/org.ligi.blexplorer I/art: Increasing code cache capacity to 128KB
2020-03-06 15:14:12.186 26618-26618/org.ligi.blexplorer D/AndroidRuntime: Shutting down VM
2020-03-06 15:14:12.186 26618-26618/org.ligi.blexplorer D/TraceDroid: Writing unhandled exception to: /data/user/0/org.ligi.blexplorer/files/1.2-1583504052186.tracedroid
2020-03-06 15:14:12.189 26618-26618/org.ligi.blexplorer D/TraceDroid: java.lang.ArrayIndexOutOfBoundsException: src.length=19 srcPos=2 dst.length=49 dstPos=0 length=49
        at java.lang.System.arraycopy(Native Method)
        at org.ligi.blexplorer.util.ManufacturerRecordParserFactory$IBeaconParser.parse(ManufacturerRecordParserFactory.java:150)
        at org.ligi.blexplorer.util.ManufacturerRecordParserFactory.parse(ManufacturerRecordParserFactory.java:30)
        at org.ligi.blexplorer.scan.DeviceViewHolder.applyDevice(DeviceViewHolder.kt:43)
        at org.ligi.blexplorer.scan.DeviceListActivity$DeviceRecycler.onBindViewHolder(DeviceListActivity.kt:49)
        at org.ligi.blexplorer.scan.DeviceListActivity$DeviceRecycler.onBindViewHolder(DeviceListActivity.kt:39)
        at android.support.v7.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:6062)
        at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:6095)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5277)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5153)
        at android.support.v7.widget.RecyclerView$Recycler.prefetch(RecyclerView.java:5932)
        at android.support.v7.widget.RecyclerView$ViewPrefetcher.run(RecyclerView.java:4524)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6186)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
2020-03-06 15:14:12.189 26618-26618/org.ligi.blexplorer E/AndroidRuntime: FATAL EXCEPTION: main
    Process: org.ligi.blexplorer, PID: 26618
    java.lang.ArrayIndexOutOfBoundsException: src.length=19 srcPos=2 dst.length=49 dstPos=0 length=49
        at java.lang.System.arraycopy(Native Method)
        at org.ligi.blexplorer.util.ManufacturerRecordParserFactory$IBeaconParser.parse(ManufacturerRecordParserFactory.java:150)
        at org.ligi.blexplorer.util.ManufacturerRecordParserFactory.parse(ManufacturerRecordParserFactory.java:30)
        at org.ligi.blexplorer.scan.DeviceViewHolder.applyDevice(DeviceViewHolder.kt:43)
        at org.ligi.blexplorer.scan.DeviceListActivity$DeviceRecycler.onBindViewHolder(DeviceListActivity.kt:49)
        at org.ligi.blexplorer.scan.DeviceListActivity$DeviceRecycler.onBindViewHolder(DeviceListActivity.kt:39)
        at android.support.v7.widget.RecyclerView$Adapter.onBindViewHolder(RecyclerView.java:6062)
        at android.support.v7.widget.RecyclerView$Adapter.bindViewHolder(RecyclerView.java:6095)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5277)
        at android.support.v7.widget.RecyclerView$Recycler.getViewForPosition(RecyclerView.java:5153)
        at android.support.v7.widget.RecyclerView$Recycler.prefetch(RecyclerView.java:5932)
        at android.support.v7.widget.RecyclerView$ViewPrefetcher.run(RecyclerView.java:4524)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6186)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:889)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:779)
``` 